### PR TITLE
feat: ajouter Heartbeat pour des pings périodiques  pour online user

### DIFF
--- a/srcs/nginx/src/api/auth-api.ts
+++ b/srcs/nginx/src/api/auth-api.ts
@@ -97,6 +97,14 @@ export const authApi = {
   },
 
   /**
+   * Indique au serveur que la session est toujours active.
+   * Appelé périodiquement tant que l'utilisateur est connecté.
+   */
+  heartbeat: async (): Promise<void> => {
+    await api.post('/auth/heartbeat');
+  },
+
+  /**
    * Échange un code d'autorisation OAuth contre un JWT
    * @param provider Provider OAuth ('google' | 'school42')
    * @param request Code d'autorisation et state

--- a/srcs/nginx/src/hooks/useHeartbeat.ts
+++ b/srcs/nginx/src/hooks/useHeartbeat.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react';
+import { authApi } from '../api/auth-api';
+
+/**
+ * Intervalle entre deux pings (ms).
+ * 30 s
+ */
+const HEARTBEAT_INTERVAL_MS = 30_000;
+
+/**
+ * Envoie des pings périodiques au serveur tant que l'utilisateur est connecté.
+ *
+ * Comportements :
+ *  - Démarre immédiatement un premier ping quand `isActive` passe à `true`
+ *  - S'arrête proprement (clearInterval + removeEventListener) dès que
+ *    `isActive` passe à `false` (logout, expiration de session).
+ *  - Skip le ping si l'onglet est masqué (Page Visibility API) pour éviter
+ *    des requêtes inutiles en arrière-plan.
+ *  - Rattrape un ping immédiatement quand l'onglet redevient visible.
+ */
+export function useHeartbeat(isActive: boolean): void {
+  // useRef évite que le timer ne provoque de re-render
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!isActive) {
+      // Nettoyage si l'utilisateur vient de se déconnecter
+      if (timerRef.current !== null) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+      return;
+    }
+
+    const beat = async (): Promise<void> => {
+      // Ne pas pinger si l'onglet est en arrière-plan
+      if (document.hidden) return;
+      try {
+        await authApi.heartbeat();
+      } catch {
+        // 401 → intercepteur AuthProvider → user=null → isActive=false → cleanup
+        // Autres erreurs réseau → ignorées (le timer réessaiera au prochain cycle)
+      }
+    };
+
+    // Premier ping immédiat pour ne pas attendre le premier intervalle
+    beat();
+
+    timerRef.current = setInterval(beat, HEARTBEAT_INTERVAL_MS);
+
+    // Rattraper le ping dès que l'onglet redevient visible
+    const onVisibilityChange = (): void => {
+      if (!document.hidden) beat();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      if (timerRef.current !== null) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [isActive]);
+}

--- a/srcs/nginx/src/providers/AuthProvider.tsx
+++ b/srcs/nginx/src/providers/AuthProvider.tsx
@@ -14,6 +14,7 @@ import { TwoFactorPendingContext } from '../types/twoFactor.types';
 import { authApi } from '../api/auth-api';
 import { profileApi } from '../api/profile-api';
 import api from '../api/api-client';
+import { useHeartbeat } from '../hooks/useHeartbeat';
 
 export const AuthContext = createContext<AuthContextType | null>(null);
 
@@ -141,11 +142,16 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   // dès le prochain re-render, sans attendre un changement de pending2FA.
   const hasPending2FA = !!pending2FA && Date.now() <= pending2FA.expiresAt;
 
+  const isLoggedIn = isAuthChecked && user !== null;
+
+  // Ping périodique → démarre au login, s'arrête au logout ou sur 401.
+  useHeartbeat(isLoggedIn);
+
   const contextValue = useMemo(
     () => ({
       user,
       isAuthChecked,
-      isLoggedIn: isAuthChecked && user !== null,
+      isLoggedIn,
       login,
       logout,
       updateUser,


### PR DESCRIPTION
feat: ajouter Heartbeat pour des pings périodiques  pour online user

Logique du dashboard implementer en react pour savoir si un user est online ou non

Ping le serveur toute les 30 secondes 
Pas de ping si logout ou si page hidden

Ping immediat au retour  